### PR TITLE
fix Dockerfile rename

### DIFF
--- a/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-docker/Dockerfile
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-docker/Dockerfile
@@ -33,4 +33,4 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY resources/model /model
 
-ENTRYPOINT ["/opt/venv/bin/python3.12", "-m", "aissemble-oip-kserve-inference.main"]
+ENTRYPOINT ["/opt/venv/bin/python3.12", "-m", "aissemble_oip_kserve_inference.main"]


### PR DESCRIPTION
just need to fix renaming docker file module name coming from https://github.com/boozallen/aissemble-open-inference-protocol/pull/64