### PR TITLE
[#82] fix missed version bump

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,6 @@ jobs:
 
       # Run build and deploy test artifacts
       - name: Build aissemble-open-inference-protocol
-        run: mvn clean deploy -B -U -Pbuild,ci
+        run: mvn clean deploy -B -U -Pdefault-build,ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aissemble-open-inference-protocol-examples/aissemble-oip-grpc/pom.xml
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-grpc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.boozallen.aissemble</groupId>
         <artifactId>aissemble-open-inference-protocol-examples</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aissemble-oip-grpc</artifactId>

--- a/aissemble-open-inference-protocol-examples/pom.xml
+++ b/aissemble-open-inference-protocol-examples/pom.xml
@@ -32,6 +32,15 @@
                         <skipDeploy>true</skipDeploy>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <configuration>
+                        <!-- We don't want to publish this module to central but want to keep upversioning during release:prepare goal is executed whenever release is done.
+                             TODO: This configuration is not fully tested and shall be tested to make sure publishing example module is skipped.-->
+                        <skipPublishing>true</skipPublishing>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -54,26 +54,20 @@
         <version.python>3.11.4</version.python>
     </properties>
 
+    <modules>
+        <module>aissemble-open-inference-protocol-fastapi</module>
+        <module>aissemble-open-inference-protocol-grpc</module>
+        <module>aissemble-open-inference-protocol-shared</module>
+        <module>aissemble-open-inference-protocol-examples</module>
+        <module>aissemble-open-inference-protocol-kserve</module>
+    </modules>
+
     <profiles>
         <profile>
             <id>default-build</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <!--
-                NOTE: There is re-definition of list of modules in release maven profile, as we omit  aissemble-open-inference-protocol-examples during release.
-                Please make sure to also change list of modules in release maven profile accordingly when making changes to below modules.
-            -->
-            <modules>
-                <module>aissemble-open-inference-protocol-fastapi</module>
-                <module>aissemble-open-inference-protocol-grpc</module>
-                <module>aissemble-open-inference-protocol-shared</module>
-                <module>aissemble-open-inference-protocol-examples</module>
-                <module>aissemble-open-inference-protocol-kserve</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>build</id>
             <distributionManagement>
                 <snapshotRepository>
                     <id>ghcr.io</id>
@@ -106,12 +100,6 @@
         </profile>
         <profile>
             <id>release</id>
-            <modules>
-                <module>aissemble-open-inference-protocol-kserve</module>
-                <module>aissemble-open-inference-protocol-grpc</module>
-                <module>aissemble-open-inference-protocol-fastapi</module>
-                <module>aissemble-open-inference-protocol-shared</module>
-            </modules>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
we have failed build in mvn clean install due to not doing version bump on one module.
This is fixing that as well as refactoring profile for cleaner code.