### PR TITLE
[#91] fix readme for better clarification

### DIFF
--- a/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/README.md
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/README.md
@@ -9,7 +9,7 @@ This example demonstrates how to containerize the aiSSEMBLE Open Interface Proto
 ## Getting Started
 * This example will make use of [KServe Inference Example](../aissemble-oip-kserve-inference/README.md) to containerize and deploy aiSSEMBLE Open Interface Protocol to KServe 
 * This example will cover REST and gRPC based API calls and will be deployed locally for demonstration purpose.
-* This Example Consists of 2 Modules:
+* This example consists of 2 modules:
   * `aissemble-oip-kserve-containerization-deploy`
     * This module contains list of helm template files needed to deploy custom model to KServe.
     * inference-service.yaml will take docker image created from aissemble-oip-kserve-containerization-docker and deploy on KServe.
@@ -22,7 +22,7 @@ This example demonstrates how to containerize the aiSSEMBLE Open Interface Proto
 ## Running REST Based Example
 1. Run ```mvn clean install``` to make sure docker image can be generated to your docker daemon.
 2. Create new namespace for testing purpose ```kubectl create namespace kserve-test```
-3. cd into kserve deployment charts ```cd aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-deploy/src/main/resources/templates```
+3. cd into KServe deployment charts ```cd aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-deploy/src/main/resources/templates```
 4. Apply Inference service helm chart to kserve-test namespace
    ```kubectl apply -n kserve-test -f ./inference-service.yaml```
 5. Once predictor pod is ready, make sure kserve-model-predictor is port forwarding into 8080
@@ -47,11 +47,11 @@ curl --request POST \
 ## Running gRPC Based Example
 1. Run ```mvn clean install``` to make sure docker image can be generated to your docker daemon.
 2. Create new namespace for testing purpose ```kubectl create namespace kserve-test```
-3. cd into kserve deployment charts ```cd aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-deploy/src/main/resources/templates```
+3. cd into KServe deployment charts ```cd aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization/aissemble-oip-kserve-containerization-deploy/src/main/resources/templates```
 4. Apply Inference service helm chart to kserve-test namespace
    ```kubectl apply -n kserve-test -f ./inference-service-grpc.yaml```
 5. Once predictor pod is ready, make sure kserve-model-predictor is port forwarding into 8081
-6. cd into kserve inference example
+6. cd into KServe inference example
 ```cd aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-containerization```
 7. Send an inference request to the gRPC service using grpc_client.py
 ``` python ./grpc_client.py```

--- a/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-inference/README.md
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-kserve/aissemble-oip-kserve-inference/README.md
@@ -12,7 +12,7 @@ This example provides simple guideline on how to hook model into aiSSEMBLE Open 
 - The example will employ simple keras tensorflow model file as a model. 
 - This only covers how handler can interact with KServe
 - [main.py](src/aissemble_oip_kserve_inference/main.py) describes how to pull `AissembleOIPKServe` handler and start the KServe Model Server.
-- `AissembleOIPKServe` is KserveHandler class for aiSSEMBLE Open Inference Protocol, in which user can instantiate and start the model server.
+- `AissembleOIPKServe` is KServeHandler class for aiSSEMBLE Open Inference Protocol, in which user can instantiate and start the model server.
 - preprocess() and postprocess() are also implemented to demonstrate user have option to override those two methods and 
 - If user wants to create Custom Predictor for their need, user can also extend `AissembleOIPKServe` handler class and implement custom logic.
 - For `DataplaneHandler`, user should be implementing their own implementation of OIP handler based on `DataplaneHandler` abstract base class.

--- a/aissemble-open-inference-protocol-kserve/README.md
+++ b/aissemble-open-inference-protocol-kserve/README.md
@@ -14,9 +14,9 @@ In order to stand up KServe Using aiSSEMBLE Open Inference Protocol, user should
 Once KServe environment is set up, user can proceed with implementing custom handler for KServe using aiSSEMBLE Open Inference Protocol.
 
 ### Implementing a Handler
-To make a custom handler to integrate with kserve, create your handler class and extend the [AissembleOIPKServe](https://github.com/boozallen/aissemble-open-inference-protocol/blob/dev/aissemble-open-inference-protocol-kserve/src/aissemble_open_inference_protocol_kserve/aissemble_oip_kserve.py).
+To make a custom handler to integrate with KServe, create your handler class and extend the [AissembleOIPKServe](https://github.com/boozallen/aissemble-open-inference-protocol/blob/dev/aissemble-open-inference-protocol-kserve/src/aissemble_open_inference_protocol_kserve/aissemble_oip_kserve.py).
 Then, implement methods based on the model's need such as load() for loading a model, and optional transformer such as preprocess() and/or postprocess() that transform input or output data for client and prediction model.
-predict method will call infer method of dataplaneHandler in which you need to implement either with [REST](../aissemble-open-inference-protocol-fastapi/README.md) or [gRPC](../aissemble-open-inference-protocol-grpc/README.md)
+predict method will call infer method of DataplaneHandler in which you need to implement.
 
 ### Example of Usage with a Handler
 Create your custom handler class with:
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     model.start()
 ```
 
-Once you built your custom image for python application for KServe and KServe setup is complete, then you can run prediction based on preferred API calls (REST or gRPC)
+Once you built your custom image for python application for KServe and KServe setup is complete, then you can run prediction based on preferred API.
 
 ## Examples
 For working examples, refer to the [Examples](https://github.com/boozallen/aissemble-open-inference-protocol/blob/dev/aissemble-open-inference-protocol-examples/README.md#kserve) documentation.


### PR DESCRIPTION
DataplaneHandler is agnostic, it can be compatible whether you are using REST or gRPC. To prevent any confusion for user to misunderstand that this needs REST or gRPC specific (which is not). I will delete any REST or gRPC mentions.