### PR TITLE
[#116] Update fastapi model loading

### DIFF
--- a/DRAFT_RELEASE_NOTES.md
+++ b/DRAFT_RELEASE_NOTES.md
@@ -5,7 +5,14 @@ To give more structure and guidance to the inference process, `model_load` has b
 
 # Breaking Changes
 
+## AissembleOIPFastAPI Initialization
+The AissembleOIPFastAPI class is now initialized with the handler and adapter instance and not the class' themselves. This was done to keep consistency across solutions.
+
+To upgrade, pass the initialized handler and adapter to the server. e.g: `AissembleOIPFastAPI(Handler, Adapter) -> AissembleOIPFastAPI(Handler(), Adapter())`
+
 ## Update Auth Config
 The gRPC authorization config variable `grpc_protected_endpoints` has been removed. Unless there is further demand, it makes the most sense to protect all or no endpoints. 
+
+To upgrade, remove the property from either you environment variables to the Krausening properties file.
 
 # What's Changed

--- a/aissemble-open-inference-protocol-examples/aissemble-oip-fastapi/aissemble-oip-fastapi-auth/src/aissemble_oip_fastapi_auth/main.py
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-fastapi/aissemble-oip-fastapi-auth/src/aissemble_oip_fastapi_auth/main.py
@@ -109,5 +109,5 @@ os.environ["KRAUSENING_BASE"] = os.getcwd() + "/src/resources/krausening/base/"
 
 # To enable authorization in your own project you need to inject AuthzforceAdapter
 # into your app like the example below
-server = AissembleOIPFastAPI(Handler, AuthzforceAdapter).server
+server = AissembleOIPFastAPI(Handler(), AuthzforceAdapter()).server
 server.include_router(routerWithSecurity)

--- a/aissemble-open-inference-protocol-examples/aissemble-oip-fastapi/aissemble-oip-fastapi-inference/src/aissemble_oip_fastapi_inference/main.py
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-fastapi/aissemble-oip-fastapi-inference/src/aissemble_oip_fastapi_inference/main.py
@@ -11,6 +11,7 @@ import asyncio
 
 import numpy as np
 from typing import Optional
+from krausening.logging import LogManager
 from aissemble_open_inference_protocol_fastapi.aissemble_oip_fastapi import (
     AissembleOIPFastAPI,
 )
@@ -36,10 +37,12 @@ class Handler(DataplaneHandler):
     If this handlers doesn't implement one of Open Inferencing Protocol endpoints it would default to DataplaneHandler
     """
 
+    logger = LogManager.get_instance().get_logger("Handler")
+
     def __init__(self):
         super().__init__()
         self.model = None
-        self.ready = self.model_load("convert_celsius_to_fahrenheit")
+        self.ready = False
 
     def infer(
         self,
@@ -109,11 +112,13 @@ class Handler(DataplaneHandler):
     def model_load(self, model_name) -> bool:
         self.model = load_model("model/" + model_name + ".keras")
         self.ready = True
+        self.logger.info("Model loaded successfully")
         return True
 
 
 async def start():
-    fastapi = AissembleOIPFastAPI(Handler)
+    fastapi = AissembleOIPFastAPI(Handler())
+    fastapi.model_load("convert_celsius_to_fahrenheit")
     await fastapi.start_server()
 
 

--- a/aissemble-open-inference-protocol-examples/aissemble-oip-grpc/aissemble-oip-grpc-inference/README.md
+++ b/aissemble-open-inference-protocol-examples/aissemble-oip-grpc/aissemble-oip-grpc-inference/README.md
@@ -18,7 +18,7 @@ This example demonstrates how to implement custom handlers for all Open Inferenc
     ```sh
     poetry run run_server
     ```
-    The server will start on `grpc://0.0.0.0:8080`
+    The server will start on `grpc://0.0.0.0:8081`
 
 
 2. Run the following `grpcurl` commands to test the different endpoints:

--- a/aissemble-open-inference-protocol-fastapi/README.md
+++ b/aissemble-open-inference-protocol-fastapi/README.md
@@ -89,7 +89,7 @@ Use `aissemble-open-inference-protocol-fastapi` to create a FastAPI app and pass
 ```python
 from aissemble_open_inference_protocol_fastapi.aissemble_oip_fastapi import AissembleOIPFastAPI
 
-fastapi_server = AissembleOIPFastAPI(MyHandler).server
+fastapi_server = AissembleOIPFastAPI(MyHandler()).server
 ```
 
 Now when starting the FastAPI server, the inference request will route to `MyHandler.infer()`

--- a/aissemble-open-inference-protocol-fastapi/src/aissemble_open_inference_protocol_fastapi/aissemble_oip_fastapi.py
+++ b/aissemble-open-inference-protocol-fastapi/src/aissemble_open_inference_protocol_fastapi/aissemble_oip_fastapi.py
@@ -13,8 +13,12 @@ from fastapi import FastAPI
 from aissemble_open_inference_protocol_shared.aissemble_oip_service import (
     AissembleOIPService,
 )
+from aissemble_open_inference_protocol_shared.auth.auth_adapter_base import (
+    AuthAdapterBase,
+)
 from aissemble_open_inference_protocol_shared.handlers.dataplane import (
     DefaultHandler,
+    DataplaneHandler,
 )
 
 from aissemble_open_inference_protocol_shared.auth.default_adapter import (
@@ -25,17 +29,25 @@ import uvicorn
 
 
 class AissembleOIPFastAPI(AissembleOIPService):
-    def __init__(self, handler=None, adapter=None):
+    def __init__(
+        self, handler: DataplaneHandler = None, adapter: AuthAdapterBase = None
+    ):
         super().__init__(handler, adapter)
         self.server = FastAPI()
         self.server.include_router(endpoints.router)
         if self.handler is not None:
-            self.server.dependency_overrides[DefaultHandler] = handler
+            self.server.dependency_overrides[DefaultHandler] = self._get_handler
         if self.adapter is not None:
-            self.server.dependency_overrides[DefaultAdapter] = adapter
+            self.server.dependency_overrides[DefaultAdapter] = self._get_adapter
+
+    def _get_handler(self):
+        return self.handler
+
+    def _get_adapter(self):
+        return self.adapter
 
     def model_load(self, model_name: str) -> bool:
-        return self.handler().model_load(model_name)
+        return self.handler.model_load(model_name)
 
     async def start_server(self):
         config = uvicorn.Config(

--- a/aissemble-open-inference-protocol-fastapi/tests/features/custom_handler.feature
+++ b/aissemble-open-inference-protocol-fastapi/tests/features/custom_handler.feature
@@ -1,19 +1,12 @@
 Feature: Customization of aissemble OIP Handler
   User should be able to provide custom implementation of handler logic so that they can integrate user's logic with ML model.
 
-  Scenario: Handler implementations doesn't have required methods
-    Given custom implementation of dataplane handler that doesn't implement required methods
-    When model method is called
-    Then Error is raised
-
   Scenario: Handler implementations have default server status methods
     Given custom implementation of dataplane handler that doesn't implement server methods
     When server status method is called
     Then affirmative is responded
 
-
   Scenario: Handler implementations have overridden server status methods.
     Given custom implementation of dataplane handler that override implement server methods
     When server status method is called
     Then custom logic is reponded
-

--- a/aissemble-open-inference-protocol-fastapi/tests/features/steps/custom_handler_steps.py
+++ b/aissemble-open-inference-protocol-fastapi/tests/features/steps/custom_handler_steps.py
@@ -5,9 +5,6 @@ from fastapi.testclient import TestClient
 from aissemble_open_inference_protocol_fastapi.aissemble_oip_fastapi import (
     AissembleOIPFastAPI,
 )
-from steps.handler_without_required_impl import (
-    HandlerNoImpl,
-)
 
 from steps.handler_without_optional_impl import (
     HandlerNoOptionalImpl,
@@ -19,18 +16,10 @@ from steps.handler_with_overridden_impl import (
 
 
 @given(
-    "custom implementation of dataplane handler that doesn't implement required methods"
-)
-def given_custom_handler_without_required_methods(context):
-    api = AissembleOIPFastAPI(HandlerNoImpl)
-    context.client = TestClient(api.server)
-
-
-@given(
     "custom implementation of dataplane handler that doesn't implement server methods"
 )
 def given_custom_handler_without_optional_methods(context):
-    api = AissembleOIPFastAPI(HandlerNoOptionalImpl)
+    api = AissembleOIPFastAPI(HandlerNoOptionalImpl())
     context.client = TestClient(api.server)
 
 
@@ -38,7 +27,7 @@ def given_custom_handler_without_optional_methods(context):
     "custom implementation of dataplane handler that override implement server methods"
 )
 def given_custom_handler_overridden_methods(context):
-    api = AissembleOIPFastAPI(HandlerOverriddenImpl)
+    api = AissembleOIPFastAPI(HandlerOverriddenImpl())
     context.client = TestClient(api.server)
 
 
@@ -85,11 +74,6 @@ def send_method_request_with_exception_handle(context, method, path):
             context.schema = context.response.json()
     except Exception as ex:
         context.exception = ex
-
-
-@then("Error is raised")
-def status_code_is_error(context):
-    assert isinstance(context.exception, TypeError)
 
 
 @then("affirmative is responded")

--- a/aissemble-open-inference-protocol-fastapi/tests/features/steps/fastapi_steps.py
+++ b/aissemble-open-inference-protocol-fastapi/tests/features/steps/fastapi_steps.py
@@ -26,7 +26,7 @@ def given_i_have_fastapi_app(context):
 
 @given("I have a handler that returns outputs data")
 def i_have_a_handler_that_returns_outputs_data(context):
-    context.handler = TestHandler
+    context.handler = TestHandler()
 
 
 @given("I have an OIP FastAPI app with the handler")

--- a/aissemble-open-inference-protocol-shared/src/aissemble_open_inference_protocol_shared/aissemble_oip_service.py
+++ b/aissemble-open-inference-protocol-shared/src/aissemble_open_inference_protocol_shared/aissemble_oip_service.py
@@ -8,7 +8,6 @@
 # #L%
 ###
 from abc import ABC, abstractmethod
-from typing import Optional, Type, Union
 
 from aissemble_open_inference_protocol_shared.auth.auth_adapter_base import (
     AuthAdapterBase,
@@ -26,8 +25,8 @@ class AissembleOIPService(ABC):
 
     def __init__(
         self,
-        handler: Union[DataplaneHandler, Type[DataplaneHandler]],
-        adapter: Optional[Union[AuthAdapterBase, Type[AuthAdapterBase]]],
+        handler: DataplaneHandler,
+        adapter: AuthAdapterBase,
     ):
         super(AissembleOIPService, self).__init__()
         self.config = OIPConfig()


### PR DESCRIPTION
Model loading can now be ran and persist across rest calls. Dependency injection now gets the existing handler and adapter instead of creating a new instance.