### PR TITLE
[#132] Pin uvicorn version

### DIFF
--- a/aissemble-open-inference-protocol-fastapi/pyproject.toml
+++ b/aissemble-open-inference-protocol-fastapi/pyproject.toml
@@ -34,7 +34,8 @@ pydantic = "^2.11.4"
 PyJWT="^2.10.1"
 krausening = ">=20"
 cryptography = ">=44.0.1"
-uvicorn = ">=0.35.0"
+# Pinned to this version to stay compatible with the aiSSEMBLE OIP Kserve implementation
+uvicorn = ">=0.30.6,<0.31.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.12"


### PR DESCRIPTION
Set the uvicorn version to the same version that Kserve is using. Helps users transition from our Fastapi solution to Kserve